### PR TITLE
[CBListenerUpdate_Issue3] - Update call back listener method to include new descriptors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 }
 
 group 'com.gojek'
-version '2.0.17'
+version '3.0.0'
 
 dependencies {
     compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'

--- a/src/main/java/com/gojek/de/stencil/cache/DescriptorCacheLoader.java
+++ b/src/main/java/com/gojek/de/stencil/cache/DescriptorCacheLoader.java
@@ -76,7 +76,7 @@ public class DescriptorCacheLoader extends CacheLoader<String, Map<String, Descr
                 Descriptors.Descriptor newDescriptorForProto = newDescriptorAndTypeName != null ? newDescriptorAndTypeName.getDescriptor() : null;
                 if (prevDescriptorForProto != null && !prevDescriptorForProto.toProto().equals(newDescriptorForProto.toProto())) {
                     logger.info("Proto has changed for {}", proto);
-                    this.protoUpdateListener.onProtoUpdate();
+                    this.protoUpdateListener.onProtoUpdate(url, newDescriptorsMap);
                 }
             }
 

--- a/src/main/java/com/gojek/de/stencil/cache/ProtoUpdateListener.java
+++ b/src/main/java/com/gojek/de/stencil/cache/ProtoUpdateListener.java
@@ -1,5 +1,9 @@
 package com.gojek.de.stencil.cache;
 
+import com.gojek.de.stencil.models.DescriptorAndTypeName;
+
+import java.util.Map;
+
 public abstract class ProtoUpdateListener {
     private String proto;
 
@@ -13,4 +17,6 @@ public abstract class ProtoUpdateListener {
     }
 
     public abstract void onProtoUpdate();
+
+    public abstract void onProtoUpdate(String url, final Map<String, DescriptorAndTypeName> newDescriptor);
 }

--- a/src/main/java/com/gojek/de/stencil/utils/StencilUtils.java
+++ b/src/main/java/com/gojek/de/stencil/utils/StencilUtils.java
@@ -1,0 +1,50 @@
+package com.gojek.de.stencil.utils;
+
+import com.gojek.de.stencil.exception.StencilRuntimeException;
+import com.gojek.de.stencil.models.DescriptorAndTypeName;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.protobuf.Descriptors;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Utility method to parse the types and packages based on the descriptors.
+ */
+public class StencilUtils {
+
+    /**
+     * Gets a map of proto package name and typeName from the supplied map of model descriptors
+     *
+     * @param allDescriptors - Stencil modelled descriptors
+     * @return - map of proto package and java type
+     */
+    public static Map<String, String> getTypeNameToPackageNameMap(final Map<String, DescriptorAndTypeName> allDescriptors) {
+        Map<String, String> typeNameMap = new HashMap();
+        allDescriptors.entrySet().stream().forEach((mapEntry) -> {
+            DescriptorAndTypeName descriptorAndTypeName = (DescriptorAndTypeName)mapEntry.getValue();
+            if (descriptorAndTypeName != null) {
+                typeNameMap.put(descriptorAndTypeName.getTypeName(), mapEntry.getKey());
+            }
+        });
+        return typeNameMap;
+    }
+
+    /**
+     * Gets a map of type and the descriptor from the supplied map of model descriptors
+     *
+     * @param allDescriptors - Stencil modelled descriptors
+     * @return - map of type and the respective protobuff descriptor
+     */
+    public static Map<String, Descriptors.Descriptor> getAllProtobuffDescriptors(final Map<String, DescriptorAndTypeName> allDescriptors) {
+        Map<String, Descriptors.Descriptor> descriptorMap = new HashMap();
+        allDescriptors.entrySet().stream().forEach((mapEntry) -> {
+            DescriptorAndTypeName descriptorAndTypeName = (DescriptorAndTypeName)mapEntry.getValue();
+            if (descriptorAndTypeName != null) {
+                descriptorMap.put(mapEntry.getKey(), descriptorAndTypeName.getDescriptor());
+            }
+        });
+        return descriptorMap;
+    }
+}

--- a/src/test/java/com/gojek/de/stencil/cache/DescriptorCacheLoaderTest.java
+++ b/src/test/java/com/gojek/de/stencil/cache/DescriptorCacheLoaderTest.java
@@ -3,6 +3,7 @@ package com.gojek.de.stencil.cache;
 import com.gojek.de.stencil.exception.StencilRuntimeException;
 import com.gojek.de.stencil.http.RemoteFile;
 import com.gojek.de.stencil.models.DescriptorAndTypeName;
+import com.gojek.stencil.TestKey;
 import com.gojek.stencil.TestMessage;
 import com.google.common.io.ByteStreams;
 import com.google.protobuf.Descriptors.Descriptor;
@@ -17,6 +18,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -82,12 +84,11 @@ public class DescriptorCacheLoaderTest {
         ClassLoader classLoader = getClass().getClassLoader();
         InputStream fileInputStream = new FileInputStream(classLoader.getResource(DESCRIPTOR_FILE_PATH).getFile());
         byte[] bytes = ByteStreams.toByteArray(fileInputStream);
-        when(remoteFile.fetch(anyString())).thenReturn(bytes);
+        when(remoteFile.fetch(LOOKUP_KEY)).thenReturn(bytes);
         DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), protoUpdateListener);
         Map<String, DescriptorAndTypeName> prevDescriptor = new HashMap<>();
-        TestMessage t = TestMessage.newBuilder().setSampleString("sample_value").build();
-        prevDescriptor.put(LOOKUP_KEY, new DescriptorAndTypeName(t.getDescriptorForType(), TYPENAME_KEY));
+        prevDescriptor.put(LOOKUP_KEY, new DescriptorAndTypeName(TestKey.getDescriptor(), TYPENAME_KEY));
         assertTrue(cacheLoader.reload(LOOKUP_KEY, prevDescriptor).get().containsKey(LOOKUP_KEY));
-        verify(protoUpdateListener, times(1)).onProtoUpdate();
+        verify(protoUpdateListener, times(1)).onProtoUpdate(any(String.class), any(Map.class));
     }
 }


### PR DESCRIPTION
Enables a new proto update listener method that takes the new descriptors fetched and
that are changed during the fetch. This will avoid the cache returning the stale value if the listener thread did not update the cache with the new value. The existing callback listener along with the client implementation provisions to fetch the new descriptor from the cache when the cache is updated in the background.