### PR TITLE
[Kush] Ability to re-fetch stencil on-demand

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 }
 
 group 'com.gojek'
-version '4.1.0'
+version '4.2.0'
 
 dependencies {
     compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'

--- a/src/main/java/com/gojek/de/stencil/StencilClientFactory.java
+++ b/src/main/java/com/gojek/de/stencil/StencilClientFactory.java
@@ -6,33 +6,39 @@ import com.gojek.de.stencil.client.ClassLoadStencilClient;
 import com.gojek.de.stencil.client.MultiURLStencilClient;
 import com.gojek.de.stencil.client.StencilClient;
 import com.gojek.de.stencil.client.URLStencilClient;
+import com.gojek.de.stencil.config.StencilConfig;
 import com.gojek.de.stencil.http.RemoteFileImpl;
 import com.gojek.de.stencil.http.RetryHttpClient;
 import com.timgroup.statsd.NoOpStatsDClient;
 import com.timgroup.statsd.StatsDClient;
+import org.aeonbits.owner.ConfigFactory;
 
 import java.util.List;
 import java.util.Map;
 
 public class StencilClientFactory {
     public static StencilClient getClient(String url, Map<String, String> config, StatsDClient statsDClient) {
-        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(new RemoteFileImpl(new RetryHttpClient().create(config)), statsDClient, null);
-        return new URLStencilClient(url, config, cacheLoader);
+        StencilConfig stencilConfig = ConfigFactory.create(StencilConfig.class, config);
+        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(new RemoteFileImpl(new RetryHttpClient().create(config)), statsDClient, null, stencilConfig.shouldAutoRefreshCache());
+        return new URLStencilClient(url, stencilConfig, cacheLoader);
     }
 
     public static StencilClient getClient(String url, Map<String, String> config, StatsDClient statsDClient, ProtoUpdateListener protoUpdateListener) {
-        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(new RemoteFileImpl(new RetryHttpClient().create(config)), statsDClient, protoUpdateListener);
-        return new URLStencilClient(url, config, cacheLoader);
+        StencilConfig stencilConfig = ConfigFactory.create(StencilConfig.class, config);
+        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(new RemoteFileImpl(new RetryHttpClient().create(config)), statsDClient, protoUpdateListener, stencilConfig.shouldAutoRefreshCache());
+        return new URLStencilClient(url, stencilConfig, cacheLoader);
     }
 
     public static StencilClient getClient(List<String> urls, Map<String, String> config, StatsDClient statsDClient) {
-        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(new RemoteFileImpl(new RetryHttpClient().create(config)), statsDClient, null);
-        return new MultiURLStencilClient(urls, config, cacheLoader);
+        StencilConfig stencilConfig = ConfigFactory.create(StencilConfig.class, config);
+        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(new RemoteFileImpl(new RetryHttpClient().create(config)), statsDClient, null, stencilConfig.shouldAutoRefreshCache());
+        return new MultiURLStencilClient(urls, stencilConfig, cacheLoader);
     }
 
     public static StencilClient getClient(List<String> urls, Map<String, String> config, StatsDClient statsDClient, ProtoUpdateListener protoUpdateListener) {
-        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(new RemoteFileImpl(new RetryHttpClient().create(config)), statsDClient, protoUpdateListener);
-        return new MultiURLStencilClient(urls, config, cacheLoader);
+        StencilConfig stencilConfig = ConfigFactory.create(StencilConfig.class, config);
+        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(new RemoteFileImpl(new RetryHttpClient().create(config)), statsDClient, protoUpdateListener, stencilConfig.shouldAutoRefreshCache());
+        return new MultiURLStencilClient(urls, stencilConfig, cacheLoader);
     }
 
     public static StencilClient getClient(String url, Map<String, String> config) {

--- a/src/main/java/com/gojek/de/stencil/cache/DescriptorCacheLoader.java
+++ b/src/main/java/com/gojek/de/stencil/cache/DescriptorCacheLoader.java
@@ -5,6 +5,7 @@ import com.gojek.de.stencil.exception.StencilRuntimeException;
 import com.gojek.de.stencil.http.RemoteFile;
 import com.gojek.de.stencil.models.DescriptorAndTypeName;
 import com.google.common.cache.CacheLoader;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
 import com.google.protobuf.Descriptors;
@@ -18,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -28,13 +30,14 @@ public class DescriptorCacheLoader extends CacheLoader<String, Map<String, Descr
     private ExecutorService executor = Executors.newFixedThreadPool(DEFAULT_THREAD_POOL);
     private RemoteFile remoteFile;
     private ProtoUpdateListener protoUpdateListener;
+    private boolean asyncRefresh;
 
-    public DescriptorCacheLoader(RemoteFile remoteFile, StatsDClient statsDClient, ProtoUpdateListener protoUpdateListener) {
+    public DescriptorCacheLoader(RemoteFile remoteFile, StatsDClient statsDClient, ProtoUpdateListener protoUpdateListener, boolean asyncRefresh) {
         this.remoteFile = remoteFile;
         this.statsDClient = statsDClient;
         this.protoUpdateListener = protoUpdateListener;
+        this.asyncRefresh = asyncRefresh;
     }
-
 
     @Override
     public Map<String, DescriptorAndTypeName> load(String key) {
@@ -45,6 +48,9 @@ public class DescriptorCacheLoader extends CacheLoader<String, Map<String, Descr
     @Override
     public ListenableFuture<Map<String, DescriptorAndTypeName>> reload(final String key, final Map<String, DescriptorAndTypeName> prevDescriptor) {
         logger.info("reloading the cache to get the new descriptors");
+        if(!asyncRefresh) {
+            return Futures.immediateFuture(refreshMap(key, prevDescriptor));
+        }
         ListenableFutureTask<Map<String, DescriptorAndTypeName>> task = ListenableFutureTask.create(
                 () -> {
                     try {
@@ -59,25 +65,22 @@ public class DescriptorCacheLoader extends CacheLoader<String, Map<String, Descr
         return task;
     }
 
-
     private Map<String, DescriptorAndTypeName> refreshMap(String url, final Map<String, DescriptorAndTypeName> prevDescriptor) {
         try {
             logger.info("fetching descriptors from {}", url);
             byte[] descriptorBin = remoteFile.fetch(url);
             logger.info("successfully fetched {}", url);
             InputStream inputStream = new ByteArrayInputStream(descriptorBin);
-            statsDClient.count("stencil.client.refresh" + ",status=success", 1);
+            statsDClient.count("stencil.client.refresh,status=success", 1);
             Map<String, DescriptorAndTypeName> newDescriptorsMap = new DescriptorMapBuilder().buildFrom(inputStream);
 
-            if (this.protoUpdateListener != null) {
-                if (!prevDescriptor.isEmpty()) {
-                    this.protoUpdateListener.onProtoUpdate(url, newDescriptorsMap);
-                }
+            if (protoUpdateListener != null && !prevDescriptor.isEmpty()) {
+                protoUpdateListener.onProtoUpdate(url, newDescriptorsMap);
             }
 
             return newDescriptorsMap;
         } catch (IOException | Descriptors.DescriptorValidationException e) {
-            statsDClient.count("stencil.client.refresh" + ",status=failed", 1);
+            statsDClient.count("stencil.client.refresh,status=failed", 1);
             throw new StencilRuntimeException(e);
         }
     }

--- a/src/main/java/com/gojek/de/stencil/client/ClassLoadStencilClient.java
+++ b/src/main/java/com/gojek/de/stencil/client/ClassLoadStencilClient.java
@@ -48,4 +48,9 @@ public class ClassLoadStencilClient implements Serializable, StencilClient {
     @Override
     public void close() {
     }
+
+    @Override
+    public void refresh() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/main/java/com/gojek/de/stencil/client/MultiURLStencilClient.java
+++ b/src/main/java/com/gojek/de/stencil/client/MultiURLStencilClient.java
@@ -1,6 +1,7 @@
 package com.gojek.de.stencil.client;
 
 import com.gojek.de.stencil.cache.DescriptorCacheLoader;
+import com.gojek.de.stencil.config.StencilConfig;
 import com.gojek.de.stencil.models.DescriptorAndTypeName;
 import com.google.protobuf.Descriptors;
 
@@ -16,7 +17,7 @@ public class MultiURLStencilClient implements Serializable, StencilClient {
 
     private List<StencilClient> stencilClients;
 
-    public MultiURLStencilClient(List<String> urls, Map<String, String> config, DescriptorCacheLoader cacheLoader) {
+    public MultiURLStencilClient(List<String> urls, StencilConfig config, DescriptorCacheLoader cacheLoader) {
         stencilClients = urls.stream().map(url -> new URLStencilClient(url, config, cacheLoader)).collect(Collectors.toList());
     }
 
@@ -58,6 +59,13 @@ public class MultiURLStencilClient implements Serializable, StencilClient {
             } catch (IOException e) {
                 e.printStackTrace();
             }
+        });
+    }
+
+    @Override
+    public void refresh() {
+        stencilClients.forEach(c -> {
+            c.refresh();
         });
     }
 }

--- a/src/main/java/com/gojek/de/stencil/client/StencilClient.java
+++ b/src/main/java/com/gojek/de/stencil/client/StencilClient.java
@@ -20,4 +20,6 @@ public interface StencilClient extends Closeable {
         if (podName != null) return podName;
         return "";
     }
+
+    void refresh();
 }

--- a/src/main/java/com/gojek/de/stencil/config/StencilConfig.java
+++ b/src/main/java/com/gojek/de/stencil/config/StencilConfig.java
@@ -17,7 +17,7 @@ public interface StencilConfig extends Config{
 
     @Key("REFRESH_CACHE")
     @DefaultValue("false")
-    Boolean shouldRefreshCache();
+    Boolean shouldAutoRefreshCache();
 
     @Key("TIL_IN_MINUTES")
     @DefaultValue("0")

--- a/src/main/java/com/gojek/de/stencil/parser/ProtoParserWithRefresh.java
+++ b/src/main/java/com/gojek/de/stencil/parser/ProtoParserWithRefresh.java
@@ -1,0 +1,60 @@
+package com.gojek.de.stencil.parser;
+
+import com.gojek.de.stencil.client.StencilClient;
+import com.gojek.de.stencil.exception.StencilRuntimeException;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.timgroup.statsd.NoOpStatsDClient;
+import com.timgroup.statsd.StatsDClient;
+
+import java.time.Instant;
+
+public class ProtoParserWithRefresh implements Parser {
+    private StencilClient stencilClient;
+    private StatsDClient statsDClient;
+    private String protoClassName;
+
+    public ProtoParserWithRefresh(StencilClient stencilClient, StatsDClient statsDClient, String protoClassName) {
+        this.stencilClient = stencilClient;
+        this.statsDClient = statsDClient;
+        this.protoClassName = protoClassName;
+    }
+
+    public ProtoParserWithRefresh(StencilClient stencilClient, String protoClassName) {
+        this(stencilClient, new NoOpStatsDClient(), protoClassName);
+    }
+
+    public DynamicMessage parse(byte[] bytes) throws InvalidProtocolBufferException {
+        Instant start = Instant.now();
+        Descriptors.Descriptor descriptor = getDescriptor();
+        if (descriptor == null) {
+            throw new StencilRuntimeException(new Throwable(String.format("No Descriptors found for %s", protoClassName)));
+        }
+        DynamicMessage parsedMessage = getMessage(bytes, descriptor);
+        statsDClient.recordExecutionTime("stencil.exec.time,name=" + stencilClient.getAppName(), Instant.now().toEpochMilli() - start.toEpochMilli() );
+        return parsedMessage;
+    }
+
+    private DynamicMessage getMessage(byte[] bytes, Descriptors.Descriptor descriptor) throws InvalidProtocolBufferException {
+        DynamicMessage parsedMessage = DynamicMessage.parseFrom(descriptor, bytes);
+        if (!hasUnknownFields(parsedMessage)) {
+            return parsedMessage;
+        }
+        stencilClient.refresh();
+        return DynamicMessage.parseFrom(descriptor, bytes);
+    }
+
+    private Descriptors.Descriptor getDescriptor() {
+        Descriptors.Descriptor descriptor = stencilClient.get(protoClassName);
+        if (descriptor != null) {
+            return descriptor;
+        }
+        stencilClient.refresh();
+        return stencilClient.get(protoClassName);
+    }
+
+    private boolean hasUnknownFields(DynamicMessage parsedMessage) {
+        return parsedMessage.getUnknownFields().asMap().size() > 0;
+    }
+}

--- a/src/test/java/com/gojek/de/stencil/URLStencilClientTest.java
+++ b/src/test/java/com/gojek/de/stencil/URLStencilClientTest.java
@@ -8,6 +8,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,7 +30,7 @@ public class URLStencilClientTest {
     }
 
     @Test
-    public void downloadFile() {
+    public void downloadFile() throws IOException {
         String url = "http://localhost:8082/descriptors.bin";
         Map<String, String> config = new HashMap<>();
         StencilClient c = StencilClientFactory.getClient(url, config);
@@ -37,6 +38,8 @@ public class URLStencilClientTest {
         assertNotNull(descMap);
         Descriptors.Descriptor desc = c.get("com.gojek.stencil.TestMessage");
         assertNotNull(desc);
+        c.refresh();
+        c.close();
     }
 
 }

--- a/src/test/java/com/gojek/de/stencil/cache/DescriptorCacheLoaderTest.java
+++ b/src/test/java/com/gojek/de/stencil/cache/DescriptorCacheLoaderTest.java
@@ -33,7 +33,7 @@ public class DescriptorCacheLoaderTest {
     public void testStencilCacheLoadOnException() throws Exception {
         RemoteFile remoteFile = mock(RemoteFile.class);
         when(remoteFile.fetch(anyString())).thenThrow(new ClientProtocolException(""));
-        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), null);
+        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), null, true);
         cacheLoader.load(LOOKUP_KEY);
     }
 
@@ -45,7 +45,7 @@ public class DescriptorCacheLoaderTest {
         byte[] bytes = ByteStreams.toByteArray(fileInputStream);
         when(remoteFile.fetch(anyString())).thenReturn(bytes);
 
-        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), null);
+        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), null, true);
         assertTrue(cacheLoader.load(LOOKUP_KEY).containsKey(LOOKUP_KEY));
     }
 
@@ -57,7 +57,7 @@ public class DescriptorCacheLoaderTest {
         byte[] bytes = ByteStreams.toByteArray(fileInputStream);
         when(remoteFile.fetch(anyString())).thenReturn(bytes);
 
-        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), null);
+        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), null, true);
         Map<String, DescriptorAndTypeName> prevDescriptor = new HashMap<>();
         assertTrue(cacheLoader.reload(LOOKUP_KEY, prevDescriptor).get().containsKey(LOOKUP_KEY));
     }
@@ -67,7 +67,7 @@ public class DescriptorCacheLoaderTest {
         RemoteFile remoteFile = mock(RemoteFile.class);
         when(remoteFile.fetch(anyString())).thenThrow(new ClientProtocolException(""));
 
-        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), null);
+        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), null, true);
 
         Map<String, DescriptorAndTypeName> prevDescriptor = new HashMap<>();
         Map<String, DescriptorAndTypeName> result = cacheLoader.reload(LOOKUP_KEY, prevDescriptor).get();
@@ -83,7 +83,7 @@ public class DescriptorCacheLoaderTest {
         InputStream fileInputStream = new FileInputStream(classLoader.getResource(DESCRIPTOR_FILE_PATH).getFile());
         byte[] bytes = ByteStreams.toByteArray(fileInputStream);
         when(remoteFile.fetch(LOOKUP_KEY)).thenReturn(bytes);
-        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), protoUpdateListener);
+        DescriptorCacheLoader cacheLoader = new DescriptorCacheLoader(remoteFile, new NoOpStatsDClient(), protoUpdateListener, true);
         Map<String, DescriptorAndTypeName> prevDescriptor = new HashMap<>();
         prevDescriptor.put(LOOKUP_KEY, new DescriptorAndTypeName(TestKey.getDescriptor(), TYPENAME_KEY));
         assertTrue(cacheLoader.reload(LOOKUP_KEY, prevDescriptor).get().containsKey(LOOKUP_KEY));

--- a/src/test/java/com/gojek/de/stencil/client/URLStencilClientWithCacheTest.java
+++ b/src/test/java/com/gojek/de/stencil/client/URLStencilClientWithCacheTest.java
@@ -2,10 +2,12 @@ package com.gojek.de.stencil.client;
 
 import com.gojek.de.stencil.DescriptorMapBuilder;
 import com.gojek.de.stencil.cache.DescriptorCacheLoader;
+import com.gojek.de.stencil.config.StencilConfig;
 import com.gojek.de.stencil.exception.StencilRuntimeException;
 import com.gojek.de.stencil.models.DescriptorAndTypeName;
 import com.google.common.testing.FakeTicker;
 import com.google.protobuf.Descriptors;
+import org.aeonbits.owner.ConfigFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -14,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -38,7 +41,7 @@ public class URLStencilClientWithCacheTest {
         DescriptorCacheLoader cacheLoader = mock(DescriptorCacheLoader.class);
         when(cacheLoader.load(LOOKUP_KEY)).thenReturn(descriptorMap);
 
-        URLStencilClient stencilClient = new URLStencilClient(LOOKUP_KEY, new HashMap<>(), cacheLoader);
+        URLStencilClient stencilClient = new URLStencilClient(LOOKUP_KEY, ConfigFactory.create(StencilConfig.class, new HashMap<>()), cacheLoader);
         Descriptors.Descriptor result = stencilClient.get(LOOKUP_KEY);
 
         verify(cacheLoader, times(1)).load(LOOKUP_KEY);
@@ -51,7 +54,7 @@ public class URLStencilClientWithCacheTest {
         DescriptorCacheLoader cacheLoader = mock(DescriptorCacheLoader.class);
         when(cacheLoader.load(LOOKUP_KEY)).thenThrow(new StencilRuntimeException(new Throwable()));
 
-        URLStencilClient stencilClient = new URLStencilClient(LOOKUP_KEY, new HashMap<>(), cacheLoader);
+        URLStencilClient stencilClient = new URLStencilClient(LOOKUP_KEY, ConfigFactory.create(StencilConfig.class, new HashMap<>()), cacheLoader);
         stencilClient.get(LOOKUP_KEY);
     }
 
@@ -62,7 +65,7 @@ public class URLStencilClientWithCacheTest {
 
         FakeTicker fakeTicker = new FakeTicker();
 
-        URLStencilClient stencilClient = new URLStencilClient(LOOKUP_KEY, new HashMap<>(), cacheLoader, fakeTicker);
+        URLStencilClient stencilClient = new URLStencilClient(LOOKUP_KEY, ConfigFactory.create(StencilConfig.class, new HashMap<>()), cacheLoader, fakeTicker);
         Descriptors.Descriptor result = stencilClient.get(LOOKUP_KEY);
 
         fakeTicker.advance(1000, TimeUnit.MINUTES);
@@ -82,7 +85,7 @@ public class URLStencilClientWithCacheTest {
         Map<String, String> config = new HashMap<>();
         config.put("REFRESH_CACHE", "true");
 
-        URLStencilClient stencilClient = new URLStencilClient(LOOKUP_KEY, config, cacheLoader, fakeTicker);
+        URLStencilClient stencilClient = new URLStencilClient(LOOKUP_KEY, ConfigFactory.create(StencilConfig.class, config), cacheLoader, fakeTicker);
         Descriptors.Descriptor result = stencilClient.get(LOOKUP_KEY);
         assertNotNull(result);
 

--- a/src/test/java/com/gojek/de/stencil/parser/ProtoParserWithRefreshTest.java
+++ b/src/test/java/com/gojek/de/stencil/parser/ProtoParserWithRefreshTest.java
@@ -1,0 +1,62 @@
+package com.gojek.de.stencil.parser;
+
+import com.gojek.de.stencil.DescriptorMapBuilder;
+import com.gojek.de.stencil.client.StencilClient;
+import com.gojek.de.stencil.exception.StencilRuntimeException;
+import com.gojek.de.stencil.models.DescriptorAndTypeName;
+import com.gojek.stencil.TestMessage;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+
+public class ProtoParserWithRefreshTest {
+
+    private static final String LOOKUP_KEY = "com.gojek.stencil.TestMessage";
+    Map<String, DescriptorAndTypeName> descriptorMap;
+
+    @Before
+    public void setup() throws IOException, Descriptors.DescriptorValidationException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String DESCRIPTORS_FILE_PATH = "__files/descriptors.bin";
+        InputStream fileInputStream = new FileInputStream(classLoader.getResource(DESCRIPTORS_FILE_PATH).getFile());
+        descriptorMap = new DescriptorMapBuilder().buildFrom(fileInputStream);
+    }
+
+    @Test(expected = StencilRuntimeException.class)
+    public void testProtoParseOnException() throws InvalidProtocolBufferException {
+        StencilClient stencilClient = mock(StencilClient.class);
+        ProtoParserWithRefresh protoParser = new ProtoParserWithRefresh(stencilClient, LOOKUP_KEY);
+        protoParser.parse(TestMessage.getDefaultInstance().toByteArray());
+        verify(stencilClient, times(1)).refresh();
+    }
+
+    @Test
+    public void testProtoParseWithReload() throws IOException, DecoderException {
+        StencilClient stencilClient = mock(StencilClient.class);
+        when(stencilClient.get(LOOKUP_KEY)).thenReturn(descriptorMap.get(LOOKUP_KEY).getDescriptor());
+        ProtoParserWithRefresh protoParser = new ProtoParserWithRefresh(stencilClient, LOOKUP_KEY);
+
+        //simulate TestMessage.newBuilder().setSampleString("sample_string").setSampleSecondString("second").build().toByteArray();
+        byte[] testData = Hex.decodeHex("0a0d73616d706c655f737472696e6712067365636f6e64".toCharArray());
+
+        DynamicMessage parsed = protoParser.parse(testData);
+        assertNotNull(parsed);
+        verify(stencilClient, times(1)).refresh();
+    }
+}


### PR DESCRIPTION
Refresh `DescriptorSet` from URL if:
- Auto-refresh is turned off and it fails to find descriptor by name.
- Auto-refresh is turned off and it finds unknown fields in `DynamicMessage` after parsing.

This will remove the need for periodic stencil updates. For a downstream service wants to strictly check Kafka messages have one to one mapping with Protobuf fields, once the message is parsed using `ProtoParserWithRefresh` look for `unknownFields` in the `DynamicMessage`, if the map contains more than one field, then fail.